### PR TITLE
Updates docs generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ deploy:
     python: 3.6
 - provider: script
   skip_cleanup: true
-  script: bash scripts/deployDocs.sh shrimp.octet.services
+  script: bash scripts/deployDocs.sh shrimp.octet.services docs_deploy
   on:
     tags: true
     repo: DEX-Company/starfish-py

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,6 +49,17 @@ apidoc_module_dir = '../../starfish_py'
 apidoc_separate_modules = True
 # See https://www.sphinx-doc.org/en/master/man/sphinx-apidoc.html
 apidoc_extra_args = []
+apidoc_excluded_paths = [
+  'agent.py',
+  'asset.py',
+  'command_line',
+  'config.py',
+  'constants.py',
+  'exceptions.py',
+  'logging.py',
+  'models',
+  'utils'
+]
 
 # autodoc settings
 # Setting None is equivalent to giving the option name

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,5 +1,5 @@
 starfish-py API Reference Docs
-===========================
+==============================
 
 These docs are API Reference docs.
 

--- a/scripts/deployDocs.sh
+++ b/scripts/deployDocs.sh
@@ -28,7 +28,7 @@ pip install -e .[dev] -U tox-travis
 make docs
 
 # package into a tar.gz file for deployment
-tar -czvf "$DEPLOY_FILENAME" "$SOURCE_FILES"
+(cd "$SOURCE_FILES"; tar -czvf "../../../$DEPLOY_FILENAME" ./)
 
 if [ ! -z "$DEPLOY_SERVER" ]; then
     DEPLOY_BUILD_URL="http://${DEPLOY_SERVER}/docs_build"

--- a/starfish_py/agent.py
+++ b/starfish_py/agent.py
@@ -38,4 +38,4 @@ class Agent():
     def _register_ddo(self, did, ddo, account):
         """register a ddo object on the block chain for this agent"""
         # register/update the did->ddo to the block chain
-        return self._ocean.keeper.did_registry.register(did, ddo=ddo, account=account)
+        return self._ocean._keeper.did_registry.register(did, ddo=ddo, account=account)

--- a/starfish_py/logging.py
+++ b/starfish_py/logging.py
@@ -13,8 +13,8 @@ import coloredlogs
 
 def setup_logging(level=logging.INFO, filename='logging.yaml', env_key='LOG_CFG'):
     """
-    | **@author:** Prathyush SP, but hacked around by Bill
-    | Logging Setup
+    **@author:** Prathyush SP, but hacked around by Bill
+    Logging Setup
     """
     value = os.getenv(env_key, None)
     if value:

--- a/starfish_py/models/metadata_agent_model.py
+++ b/starfish_py/models/metadata_agent_model.py
@@ -124,7 +124,7 @@ class MetadataAgentModel(ModelBase):
 
     def _resolve_did_to_ddo(self, did):
         """resolve a DID to a given DDO, return the DDO if found"""
-        did_resolver = DIDResolver(self._ocean.web3, self._ocean.keeper.did_registry)
+        did_resolver = DIDResolver(self._ocean._web3, self._ocean._keeper.did_registry)
         resolved = did_resolver.resolve(did)
         if resolved and resolved.is_ddo:
             ddo = DDO(json_text=resolved.value)

--- a/starfish_py/models/squid_model.py
+++ b/starfish_py/models/squid_model.py
@@ -26,17 +26,17 @@ class SquidModel(ModelBase):
         :param metadata: metadata to write to the storage server
         :param account: account to register the asset
         """
-        return self._ocean.squid.register_asset(metadata, account)
+        return self._ocean._squid.register_asset(metadata, account)
 
     def read_asset(self, did):
         """ read the asset metadata(DDO) using the asset DID """
-        return self._ocean.squid.resolve_asset_did(did)
+        return self._ocean._squid.resolve_asset_did(did)
 
     def search_assets(self, text, sort=None, offset=100, page=0):
         """
         Search assets from the squid API.
         """
-        ddo_list = self._ocean.squid.search_assets_by_text(text, sort, offset, page)
+        ddo_list = self._ocean._squid.search_assets_by_text(text, sort, offset, page)
         return ddo_list
 
     def is_service_agreement_template_registered(self, template_id):
@@ -47,10 +47,9 @@ class SquidModel(ModelBase):
 
     def get_service_agreement_template_owner(self, template_id):
         """
-        :return: Owner of the registered service level agreement template, if not
-        registered then return None
+        :return: Owner of the registered service level agreement template, if not registered then return None
         """
-        return self._ocean.squid.keeper.service_agreement.get_template_owner(template_id)
+        return self._ocean._squid.keeper.service_agreement.get_template_owner(template_id)
 
     def register_service_agreement_template(self, template_id, account):
         """
@@ -62,10 +61,10 @@ class SquidModel(ModelBase):
         """
         template = ServiceAgreementTemplate.from_json_file(get_sla_template_path())
         template = register_service_agreement_template(
-            self._ocean.squid.keeper.service_agreement,
+            self._ocean._squid.keeper.service_agreement,
             account,
             template,
-            self._ocean.squid.keeper.network_name
+            self._ocean._squid.keeper.network_name
         )
         return template
 
@@ -80,7 +79,7 @@ class SquidModel(ModelBase):
         service_agreement_id = None
         service_agreement = self.get_service_agreement_from_asset(asset)
         if service_agreement:
-            service_agreement_id = self._ocean.squid.purchase_asset_service(asset.did, service_agreement.sa_definition_id, account)
+            service_agreement_id = self._ocean._squid.purchase_asset_service(asset.did, service_agreement.sa_definition_id, account)
 
         return service_agreement_id
 
@@ -89,10 +88,10 @@ class SquidModel(ModelBase):
         Conusmer the asset data, by completing the payment and later returning the data for the asset
 
         """
-        downloads_path = self._ocean.squid._downloads_path
+        downloads_path = self._ocean._squid._downloads_path
         service_agreement = self.get_service_agreement_from_asset(asset)
         if service_agreement:
-            self._ocean.squid.consume_service(service_agreement_id, asset.did, service_agreement.sa_definition_id, account)
+            self._ocean._squid.consume_service(service_agreement_id, asset.did, service_agreement.sa_definition_id, account)
 
     def is_access_granted_for_asset(self, asset, service_agreement_id, account):
         """
@@ -107,9 +106,9 @@ class SquidModel(ModelBase):
         else:
             raise TypeError(f'You need to pass an account object or account address')
 
-        agreement_address = self._ocean.keeper.service_agreement.get_service_agreement_consumer(service_agreement_id)
+        agreement_address = self._ocean._keeper.service_agreement.get_service_agreement_consumer(service_agreement_id)
 
-        return self._ocean.squid.is_access_granted(service_agreement_id, asset.did, account_address)
+        return self._ocean._squid.is_access_granted(service_agreement_id, asset.did, account_address)
 
     def get_service_agreement_from_asset(self, asset):
         """

--- a/starfish_py/ocean.py
+++ b/starfish_py/ocean.py
@@ -27,7 +27,7 @@ class Ocean():
         self._squid_ocean = SquidOcean(squid_config)
 
         # For development, we use the HTTPProvider Web3 interface
-        self._web3 = Web3(HTTPProvider(self._config.keeper_url))
+        self.__web3 = Web3(HTTPProvider(self._config.keeper_url))
 
     def register_agent(self, agent_service_name, endpoint_url, account, did=None):
         """
@@ -83,7 +83,7 @@ class Ocean():
     def get_asset(self, did):
         """
         :param: did: DID of the asset and agent combined.
-        :return a registered asset given a DID of the asset
+        :return: a registered asset given a DID of the asset
         """
         asset = None
         if Asset.is_did_valid(did):
@@ -128,17 +128,17 @@ class Ocean():
         return self._squid_ocean.get_accounts()
 
     @property
-    def web3(self):
+    def _web3(self):
         """return the web3 instance"""
-        return self._web3
+        return self.__web3
 
     @property
-    def keeper(self):
+    def _keeper(self):
         """return the keeper contracts"""
         return self._squid_ocean.keeper
 
     @property
-    def squid(self):
+    def _squid(self):
         """return squid ocean library"""
         return self._squid_ocean
 

--- a/tests/assets/_test_asset_light.py
+++ b/tests/assets/_test_asset_light.py
@@ -30,14 +30,14 @@ METADATA_SAMPLE_PATH = pathlib.Path.cwd() / 'tests' / 'resources' / 'metadata' /
 
 
 def test_asset_light():
-    
+
     """
     First part register the agent and get it's DID for later use
     """
     # create an ocean object
     ocean = Ocean( keeper_url=KEEPER_URL, contract_path=CONTRACTS_PATH)
     assert ocean
-    assert ocean.keeper
+    assert ocean._keeper
     assert ocean.accounts
 
     # in testing only account #1 is left unlocked
@@ -51,7 +51,7 @@ def test_asset_light():
     assert ddo
 
     agent_did = did
-    
+
     """
     Now re-connect to Ocean using the agent's DID and Auth access codes
     """
@@ -64,15 +64,15 @@ def test_asset_light():
     assert metadata
 
 
-    ocean = Ocean( 
-        keeper_url=KEEPER_URL, 
-        contract_path=CONTRACTS_PATH, 
+    ocean = Ocean(
+        keeper_url=KEEPER_URL,
+        contract_path=CONTRACTS_PATH,
     )
 
     # test registering an asset using an agent object
     asset = ocean.register_asset_light(
-        metadata['base'], 
-        did=agent_did, 
+        metadata['base'],
+        did=agent_did,
         authorization=METADATA_STORAGE_AUTH
     )
     assert asset

--- a/tests/assets/test_asset.py
+++ b/tests/assets/test_asset.py
@@ -113,10 +113,10 @@ def test_asset():
     # FIXME: bug in squid ... this does not work at the moment
     # see
     # https://github.com/oceanprotocol/squid-py/issues/282
-    Brizo.set_http_client(BrizoMock(ocean.squid, publisher_account))
+    Brizo.set_http_client(BrizoMock(ocean._squid, publisher_account))
 
     # so instead..
-    # Brizo.set_http_client(BrizoMock(ocean.squid, publisher_account))
+    # Brizo.set_http_client(BrizoMock(ocean._squid, publisher_account))
 
 
     # test purchase an asset


### PR DESCRIPTION
Travis scipt adds docs_deploy AS DEPLOY_USER (arg 2) to deployDocs.sh
All modules are excluded, except the public API in starfish-py.ocean.
The doc tarball is created with a relative path to the doc root.
Various Sphinx warnings have been addressed.
Certain Ocean @property's have been marked private: keeper, squid, web3

Signed-off-by: Tom Marble <tmarble@info9.net>