### PR TITLE
Feature/squid 0.4.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ services:
 before_install:
 - git clone https://github.com/DEX-Company/barge.git
 - cd barge
-- git checkout tags/dex-2019-02-18
+- git checkout tags/dex-2019-03-05
 - bash -x start_ocean.sh --no-brizo --no-pleuston --local-spree-node 2>&1 > start_ocean.log
   &
 - cd ..

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Floating on the surface of the Ocean. Ocean-py (Ocean Python) provides user acce
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/385d72f0a6314b18bedd96e808a90e46)](https://www.codacy.com/app/billbsing/starfish-py?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=DEX-Company/starfish-py&amp;utm_campaign=Badge_Grade)
 [![GitHub contributors](https://img.shields.io/github/contributors/DEX-Company/starfish-py.svg)](https://github.com/DEX-Company/starfish-py/graphs/contributors)
 [![Squid Version](https://img.shields.io/badge/squid--py-v0.4.2-blue.svg)](https://github.com/oceanprotocol/squid-py/releases/tag/v0.3.2)
-[![Barge Version](https://img.shields.io/badge/barge-dex--2019--02--18-blue.svg)](https://github.com/DEX-Company/barge/releases/tag/dex-2019-02-18)
+[![Barge Version](https://img.shields.io/badge/barge-dex--2019--03--05-blue.svg)](https://github.com/DEX-Company/barge/releases/tag/dex-2019-03-05)
 
 ---
 
@@ -50,7 +50,7 @@ Python 3.6
     ```
     git clone https://github.com/DEX-Company/barge.git
     cd barge
-    git checkout tags/dex-2019-02-18
+    git checkout tags/dex-2019-03-05
     ./start_ocean.sh --no-brizo --no-pleuston --local-spree-node
     ```
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open('CHANGELOG.md') as changelog_file:
     changelog = changelog_file.read()
 
 install_requirements = [
-    'squid-py==0.4.2',
+    'squid-py==0.4.4',
     'coloredlogs',
     'eciespy',
     'pyopenssl',

--- a/starfish/models/squid_model.py
+++ b/starfish/models/squid_model.py
@@ -101,10 +101,13 @@ class SquidModel():
 
         :return: service_agreement_id of the purchase or None if no purchase could be made
         """
+        squid_ocean = self.get_squid_ocean(account, 'consume_downloads')
+
         service_agreement_id = None
         service_agreement = SquidModel.get_service_agreement_from_ddo(ddo)
         if service_agreement:
-            service_agreement_id = self._squid_ocean.assets.order(ddo.did, service_agreement.sa_definition_id, account)
+            # service_agreement_id = self._squid_ocean.assets.order(ddo.did, service_agreement.sa_definition_id, account)
+            service_agreement_id = squid_ocean.assets.order(ddo.did, service_agreement.sa_definition_id, account)
 
         return service_agreement_id
 
@@ -113,7 +116,7 @@ class SquidModel():
         Conusmer the asset data, by completing the payment and later returning the data for the asset
 
         """
-        squid_ocean = self.get_squid_ocean(account)
+        squid_ocean = self.get_squid_ocean(account, download_path)
         service_agreement = SquidModel.get_service_agreement_from_ddo(ddo)
         if service_agreement:
             squid_ocean.assets.consume(service_agreement_id, ddo.did, service_agreement.sa_definition_id, account, download_path)
@@ -217,7 +220,7 @@ class SquidModel():
     def brizo_url(self):
         return self._brizo_url
 
-    def get_squid_ocean(self, account = None):
+    def get_squid_ocean(self, account=None, download_path=None):
         """
 
         Return an instance of squid for an account
@@ -229,6 +232,9 @@ class SquidModel():
             options['parity_address'] = account.address
             options['parity_password'] = account.password
 
+        if download_path:
+            options['download_path'] = download_path
+            
         config_params = self._as_config_dict(options)
         config = SquidConfig(options_dict=config_params)
         return SquidOcean(config)

--- a/starfish/models/squid_model.py
+++ b/starfish/models/squid_model.py
@@ -101,12 +101,10 @@ class SquidModel():
 
         :return: service_agreement_id of the purchase or None if no purchase could be made
         """
-        squid_ocean = self.get_squid_ocean(account, 'consume_downloads')
-
+        squid_ocean = self.get_squid_ocean(account)
         service_agreement_id = None
         service_agreement = SquidModel.get_service_agreement_from_ddo(ddo)
         if service_agreement:
-            # service_agreement_id = self._squid_ocean.assets.order(ddo.did, service_agreement.sa_definition_id, account)
             service_agreement_id = squid_ocean.assets.order(ddo.did, service_agreement.sa_definition_id, account)
 
         return service_agreement_id
@@ -116,7 +114,7 @@ class SquidModel():
         Conusmer the asset data, by completing the payment and later returning the data for the asset
 
         """
-        squid_ocean = self.get_squid_ocean(account, download_path)
+        squid_ocean = self.get_squid_ocean(account)
         service_agreement = SquidModel.get_service_agreement_from_ddo(ddo)
         if service_agreement:
             squid_ocean.assets.consume(service_agreement_id, ddo.did, service_agreement.sa_definition_id, account, download_path)
@@ -175,8 +173,6 @@ class SquidModel():
                 data['keeper-contracts']['parity.address'] = options['parity_address']
             if 'parity_password' in options:
                 data['keeper-contracts']['parity.password'] = options['parity_password']
-            if 'download_path' in options:
-                data['resources']['downloads.path'] = options['download_path']
 
         return data
 
@@ -220,7 +216,7 @@ class SquidModel():
     def brizo_url(self):
         return self._brizo_url
 
-    def get_squid_ocean(self, account=None, download_path=None):
+    def get_squid_ocean(self, account=None):
         """
 
         Return an instance of squid for an account
@@ -231,9 +227,6 @@ class SquidModel():
         if account:
             options['parity_address'] = account.address
             options['parity_password'] = account.password
-
-        if download_path:
-            options['download_path'] = download_path
 
         config_params = self._as_config_dict(options)
         config = SquidConfig(options_dict=config_params)

--- a/starfish/models/squid_model.py
+++ b/starfish/models/squid_model.py
@@ -234,7 +234,7 @@ class SquidModel():
 
         if download_path:
             options['download_path'] = download_path
-            
+
         config_params = self._as_config_dict(options)
         config = SquidConfig(options_dict=config_params)
         return SquidOcean(config)

--- a/tests/agents/test_squid_agent.py
+++ b/tests/agents/test_squid_agent.py
@@ -26,7 +26,12 @@ from squid_py.keeper.event_listener import EventListener
 from squid_py.brizo.brizo_provider import BrizoProvider
 from squid_py.brizo.brizo import Brizo
 
-from tests.helpers.brizo_mock import BrizoMock
+from tests.helpers.brizo_mock import (
+    BrizoMock,
+    brizo_mock_ocean_instance,
+    brizo_mock_account
+)
+
 
 setup_logging(level=logging.DEBUG)
 logging.getLogger("urllib3").setLevel(logging.WARNING)
@@ -121,8 +126,10 @@ def test_asset():
 
     # since Brizo does not work outside in the barge , we need to start
     # brizo as a dumy client to do the brizo work...
-    # BrizoProvider.set_brizo_class(BrizoMock)
-    Brizo.set_http_client(BrizoMock(model.get_squid_ocean(), publisher_account._squid_account))
+    BrizoMock.ocean_instance = model.get_squid_ocean()
+    BrizoMock.publisher_account = publisher_account._squid_account
+    BrizoProvider.set_brizo_class(BrizoMock)
+    # Brizo.set_http_client(BrizoMock(model.get_squid_ocean(), publisher_account._squid_account))
 
 
     # test purchase an asset

--- a/tests/agents/test_squid_agent.py
+++ b/tests/agents/test_squid_agent.py
@@ -129,7 +129,6 @@ def test_asset():
     BrizoMock.ocean_instance = model.get_squid_ocean()
     BrizoMock.publisher_account = publisher_account._squid_account
     BrizoProvider.set_brizo_class(BrizoMock)
-    # Brizo.set_http_client(BrizoMock(model.get_squid_ocean(), publisher_account._squid_account))
 
 
     # test purchase an asset

--- a/tests/agents/test_squid_agent.py
+++ b/tests/agents/test_squid_agent.py
@@ -26,11 +26,7 @@ from squid_py.keeper.event_listener import EventListener
 from squid_py.brizo.brizo_provider import BrizoProvider
 from squid_py.brizo.brizo import Brizo
 
-from tests.helpers.brizo_mock import (
-    BrizoMock,
-    brizo_mock_ocean_instance,
-    brizo_mock_account
-)
+from tests.helpers.brizo_mock import BrizoMock
 
 
 setup_logging(level=logging.DEBUG)

--- a/tests/helpers/brizo_mock.py
+++ b/tests/helpers/brizo_mock.py
@@ -14,9 +14,6 @@ setup_logging(level=logging.DEBUG)
 logging.getLogger("urllib3").setLevel(logging.WARNING)
 logging.getLogger("web3").setLevel(logging.WARNING)
 
-brizo_mock_ocean_instance = None
-brizo_mock_account = None
-
 class BrizoMock(object):
     publisher_account = None
     ocean_instance = None

--- a/tests/helpers/brizo_mock.py
+++ b/tests/helpers/brizo_mock.py
@@ -1,8 +1,10 @@
 import os
 import logging
 import json
+# import responses
 
 from unittest.mock import Mock
+
 from squid_py import ConfigProvider
 from squid_py.brizo.brizo import Brizo
 
@@ -12,54 +14,22 @@ setup_logging(level=logging.DEBUG)
 logging.getLogger("urllib3").setLevel(logging.WARNING)
 logging.getLogger("web3").setLevel(logging.WARNING)
 
+brizo_mock_ocean_instance = None
+brizo_mock_account = None
 
 class BrizoMock(object):
+    publisher_account = None
+    ocean_instance = None
+    
     def __init__(self, ocean_instance=None, account=None):
         self.ocean_instance = ocean_instance
-        """
-        if not ocean_instance:
-            from tests.resources.helper_functions import get_publisher_ocean_instance
-            self.ocean_instance = get_publisher_ocean_instance(
-                init_tokens=False, use_ss_mock=False, use_brizo_mock=False
-            )
-        """
+        if not self.ocean_instance:
+            self.ocean_instance = BrizoMock.ocean_instance
+
         self.account = account
-        """
-        if not account:
-            from tests.resources.helper_functions import get_publisher_account
-            self.account = get_publisher_account(ConfigProvider.get_config())
-        """
-    def get(self, url, *args, **kwargs):
-        response = Mock()
-        response.data = b'good luck squiddo.'
-        response.status_code = 200
-        response.url = 'http://mock.url/filename.mock?blahblah'
-        response.content = b'asset data goes here.'
-        return response
+        if not self.account:
+            self.account = BrizoMock.publisher_account
 
-    def post(self, url, data=None, **kwargs):
-        response = Mock()
-        logging.debug(f'mock post url {url}')
-        if url.endswith('initialize'):
-            payload = json.loads(data)
-            did = payload['did']
-            service_definition_id = payload['serviceDefinitionId']
-            agreement_id = payload['serviceAgreementId']
-            signature = payload['signature']
-            consumer_address = payload['consumerAddress']
-            self.ocean_instance.agreements.create(
-                did,
-                service_definition_id,
-                agreement_id,
-                signature,
-                consumer_address,
-                self.account
-            )
-
-            response.status_code = 201
-        else:
-            response.status_code = 404
-        return response
 
     def initialize_service_agreement(self, did, agreement_id, service_definition_id,
                                      signature, account_address, purchase_endpoint):


### PR DESCRIPTION
Now running with new squid-0.4.4
Gotchas ..
1. We now need to pass the download path when purchasing an asset. (will raise an issue with squid-py about this).
2. Running squid-0.4.2 and squid-0.4.4 on the same barge/aquarius instance will cause aquarius to crash on the 0.4.4 version. (issue: https://github.com/oceanprotocol/aquarius/issues/153)
