### PR TITLE
Feature/memory account creation

### DIFF
--- a/docs/source/classes/agent.rst
+++ b/docs/source/classes/agent.rst
@@ -4,6 +4,7 @@ Agent Classes
 .. toctree::
 
     agent/agent
-    agent/listing_agent
+    agent/invoke_agent
     agent/memory_agent
     agent/squid_agent
+    agent/surfer_agent

--- a/docs/source/classes/agent/invoke_agent.rst
+++ b/docs/source/classes/agent/invoke_agent.rst
@@ -1,0 +1,7 @@
+Invoke Agent class
+===================
+
+.. autoclass:: starfish.agent.InvokeAgent
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/classes/agent/surfer_agent.rst
+++ b/docs/source/classes/agent/surfer_agent.rst
@@ -1,7 +1,7 @@
-Listing Agent class
+Surfer Agent class
 ===================
 
-.. autoclass:: starfish.agent.ListingAgent
+.. autoclass:: starfish.agent.SurferAgent
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/source/register_a_memory_asset.rst
+++ b/docs/source/register_a_memory_asset.rst
@@ -10,7 +10,7 @@ First import the main starfish ocean library
 
 >>> from starfish import Ocean
 
-Next create an instance and a basic connection to the ocean network
+Next create an instance of the ocean library with no connection to a network
 
 >>> ocean = Ocean()
 
@@ -31,6 +31,16 @@ Some test data that I want to save for this asset
 >>> print(asset.did)
 None
 
+Create a new Account
+--------------------
+We now need to create a new account. Since the Ocean is not connected to a block 
+chain network, then we can just create an account locally.
+
+>>> register_account = ocean.create_account('any old password')
+>>> print(register_account)
+Account: 1f1a46fde8bb3a2e2f6f5b0b3aaf9d3a981365c9
+
+
 Setup the Memory Agent
 ----------------------
 
@@ -48,7 +58,7 @@ a :class:.Listing object. The listing object will contain all of the information
 for selling the asset, such as price, where to obtain the asset, any samples, and more 
 information about the asset.
 
->>> listing = agent.register_asset(asset)
+>>> listing = agent.register_asset(asset, register_account)
 >>> print(listing.asset.did)
 did:op:5caa87cc42bf4ef09a96cdc11ba5dccad3659c3618b272c8859d0c8ad4075876360ca948e17e15de6717b61c9d1562dfc3057d8cb8711b9c66702331295bc80e
 

--- a/docs/source/register_a_memory_asset.rst
+++ b/docs/source/register_a_memory_asset.rst
@@ -12,21 +12,8 @@ First import the main starfish ocean library
 
 Next create an instance and a basic connection to the ocean network
 
->>> ocean = Ocean(contracts_path='artifacts', keeper_url='http://localhost:8545')
+>>> ocean = Ocean()
 
-Loading an account
-------------------
-
-Now we need to load an account and see how much ocean tokens and Etherum ether we have.
-We will always need some ether to be able to pay for the transaction costs to register and buy an asset
-on the Ethereum network. For our memory asset we do not need to use any ether, since
-the whole registration process will be done in memory instead on the block chain.
-
-Ocean tokens will only be needed when we buy an asset.
-
->>> account = ocean.get_account('0x00bd138abd70e2f00903268f3db08f2d25677c9e')
->>> print(account.ocean_balance, account.ether_balance)
-1067 1000000003718520260000000000
 
 Create a  Memory Asset
 ----------------------
@@ -61,7 +48,7 @@ a :class:.Listing object. The listing object will contain all of the information
 for selling the asset, such as price, where to obtain the asset, any samples, and more 
 information about the asset.
 
->>> listing = agent.register_asset(asset, account)
+>>> listing = agent.register_asset(asset)
 >>> print(listing.asset.did)
 did:op:5caa87cc42bf4ef09a96cdc11ba5dccad3659c3618b272c8859d0c8ad4075876360ca948e17e15de6717b61c9d1562dfc3057d8cb8711b9c66702331295bc80e
 

--- a/examples/register_memory_asset.py
+++ b/examples/register_memory_asset.py
@@ -14,9 +14,12 @@ def main():
     """
     ocean = Ocean()
 
-    # test account to regisetr
-
+    # create a new test account to register
     register_account = ocean.create_account('any old password')
+    
+    # print the new account
+    print('my new register account', register_account)
+    
     # Now create a memory asset
     asset = MemoryAsset(data='Some test data that I want to save for this asset')
 
@@ -26,7 +29,7 @@ def main():
     # Create a new memory agent to do the work.
     agent = MemoryAgent(ocean)
 
-    # Register the memory asset.
+    # Register the memory asset, with the new account.
     listing = agent.register_asset(asset, register_account)
 
     # Print out the listing did and listing data.

--- a/examples/register_memory_asset.py
+++ b/examples/register_memory_asset.py
@@ -12,18 +12,11 @@ def main():
     You can pass 'log_level=logging.DEBUG' parameter to get full debug
     logging information.
     """
-    ocean = Ocean(contracts_path='artifacts', keeper_url='http://localhost:8545')
+    ocean = Ocean()
 
-    """
-    Get our first account - in test the account numbers are published
-    at https://docs.oceanprotocol.com/concepts/testnets/
-    """
-    account = ocean.get_account('0x00bd138abd70e2f00903268f3db08f2d25677c9e')
+    # test account to regisetr
 
-    # Print out the account's ocean balance.
-    print('my account ocean balance:', account.ocean_balance)
-    print('my account ether balance:', account.ether_balance)
-
+    register_account = ocean.create_account('any old password')
     # Now create a memory asset
     asset = MemoryAsset(data='Some test data that I want to save for this asset')
 
@@ -34,10 +27,14 @@ def main():
     agent = MemoryAgent(ocean)
 
     # Register the memory asset.
-    listing = agent.register_asset(asset, account)
+    listing = agent.register_asset(asset, register_account)
 
     # Print out the listing did and listing data.
     print('memory listing', listing.did, listing.data)
+
+
+    purchase_account = ocean.create_account('purchase password')
+    purchase = listing.purchase(purchase_account)
 
 if __name__ == '__main__':
     main()

--- a/examples/register_memory_asset.py
+++ b/examples/register_memory_asset.py
@@ -33,8 +33,5 @@ def main():
     print('memory listing', listing.did, listing.data)
 
 
-    purchase_account = ocean.create_account('purchase password')
-    purchase = listing.purchase(purchase_account)
-
 if __name__ == '__main__':
     main()

--- a/starfish/agent/__init__.py
+++ b/starfish/agent/__init__.py
@@ -2,5 +2,6 @@
 
 from starfish.agent.agent import Agent
 from starfish.agent.squid_agent import SquidAgent
+from starfish.agent.invoke_agent import InvokeAgent
 from starfish.agent.memory_agent import MemoryAgent
 from starfish.agent.surfer_agent import SurferAgent

--- a/starfish/agent/memory_agent.py
+++ b/starfish/agent/memory_agent.py
@@ -41,13 +41,13 @@ class MemoryAgent(Agent):
             'purchase': {}
         }
 
-    def register_asset(self, asset, account):
+    def register_asset(self, asset, account = None):
         """
 
         Register a memory asset with the ocean network.
 
         :param dict metadata: metadata dictionary to store for this asset.
-        :param account: Ocean account to use to register this asset.
+        :param account: Optional, since an account is not assigned to an registered memory asset.
         :type account: :class:`.Account` object to use for registration.
 
         :return: A new :class:`.Listing` object that has been registered, if failure then return None.
@@ -57,20 +57,13 @@ class MemoryAgent(Agent):
 
             metadata = json.loads('my_metadata')
             # get your publisher account
-            account = ocean.get_account('0x00bd138abd70e2f00903268f3db08f2d25677c9e')
             agent = MemoryAgent(ocean)
-            listing = agent.register_asset(metadata, account)
+            listing = agent.register_asset(metadata)
 
             if listing:
                 print(f'registered my listing asset for sale with the did {listing.did}')
 
         """
-
-        if not isinstance(account, Account):
-            raise TypeError('You need to pass an Account object')
-
-        if not account.is_valid:
-            raise ValueError('You must pass a valid account')
 
         did = id_to_did(secrets.token_hex(64))
         asset_did = did

--- a/starfish/agent/surfer_agent.py
+++ b/starfish/agent/surfer_agent.py
@@ -5,7 +5,6 @@ Surfer Agent class to provide basic functionality for Ocean Agents
 In starfish-java, this is named as `RemoteAgent`
 
 """
-
 import secrets
 import re
 import json
@@ -35,10 +34,10 @@ class SurferAgent(Agent):
     :param did: Optional did of the Surfer agent
 
     :param ddo: Optional ddo of the surfer agent, if not provided the agent
-will automatically get the DDO from the network based on the DID.
+        will automatically get the DDO from the network based on the DID.
 
     :param options: Optional opitions, only `authorization` is used to access the
-Surfer server.
+        Surfer server.
 
     """
     endPointName = 'metadata-storage'

--- a/starfish/listing/listing.py
+++ b/starfish/listing/listing.py
@@ -41,9 +41,6 @@ class Listing():
         if not isinstance(account, Account):
             raise TypeError('You need to pass an Account object')
 
-        if not account.is_valid:
-            raise ValueError('You must pass a valid account')
-
         return self._agent.purchase_asset(self, account)
 
     @property

--- a/starfish/models/squid_model.py
+++ b/starfish/models/squid_model.py
@@ -26,7 +26,7 @@ from squid_py.agreements.service_types import ServiceTypes
 from squid_py.agreements.register_service_agreement import register_service_agreement
 from squid_py.brizo.brizo_provider import BrizoProvider
 from squid_py.agreements.service_types import ACCESS_SERVICE_TEMPLATE_ID
-
+from squid_py.keeper.web3_provider import Web3Provider
 
 from squid_py.ddo.metadata import Metadata
 
@@ -295,6 +295,21 @@ class SquidModel():
         :type: tuple(eth,ocn)
         """
         return self._squid_ocean.accounts.balance(account)
+
+    def create_account(self, password):
+        """
+
+        :param str password: password of the new account
+        :return: None or squid account of the new account.
+        :type: object or None
+
+        """
+        local_account = self._ocean._web3.eth.account.create(password)
+        # need to reload squid again so that it sees the new account
+        # TODO: does not work at the moment, new account does not get
+        # shown in squid
+        self._squid_ocean = self.get_squid_ocean()
+        return local_account.address
 
     def register_ddo(self, did, ddo, account):
         """register a ddo object on the block chain for this agent"""

--- a/starfish/models/squid_model.py
+++ b/starfish/models/squid_model.py
@@ -30,7 +30,8 @@ from squid_py.keeper.web3_provider import Web3Provider
 
 from squid_py.ddo.metadata import Metadata
 
-logger = logging.getLogger('ocean')
+
+logger = logging.getLogger('starfish')
 # from starfish import logger
 
 class SquidModel():
@@ -304,11 +305,16 @@ class SquidModel():
         :type: object or None
 
         """
-        local_account = self._ocean._web3.eth.account.create(password)
+        local_account = Web3Provider.get_web3().eth.account.create(password)
         # need to reload squid again so that it sees the new account
         # TODO: does not work at the moment, new account does not get
         # shown in squid
+        logger.info(f'new account address {local_account.address}')
         self._squid_ocean = self.get_squid_ocean()
+        account_list = Web3Provider.get_web3().eth.accounts
+        logger.info(f'current account list {account_list}')
+        account = self.get_account(local_account.address, password)
+        logger.info(f'found account {account}')
         return local_account.address
 
     def register_ddo(self, did, ddo, account):

--- a/starfish/ocean/ocean.py
+++ b/starfish/ocean/ocean.py
@@ -4,6 +4,7 @@ Ocean class to access the Ocean eco system.
 
 """
 import logging
+import secrets
 
 from web3 import (
     Web3,
@@ -74,6 +75,7 @@ class Ocean():
         self._gas_limit = kwargs.get('gas_limit', 0)
         setup_logging(level = kwargs.get('log_level', logging.WARNING))
 
+        self.__web3 = None
         # For development, we use the HTTPProvider Web3 interface
         if self._keeper_url:
             self.__web3 = Web3(HTTPProvider(self._keeper_url))
@@ -85,6 +87,7 @@ class Ocean():
         # only use squid or simiiar if we have the keeper url setup
         if self._keeper_url:
             self.__squid_model_class = kwargs.get('squid_model_class', SquidModel)
+
 
     def register_update_agent_service(self, service_name, endpoint_url, account, did=None):
         """
@@ -162,6 +165,31 @@ class Ocean():
         if account.is_valid:
             return account
         return None
+
+    def create_account(self, password):
+        """
+        Create a new account object on the connected network. If the ocean object is
+        not connected to a network, then a test address will be created
+
+        :param password: optional password to save with the account
+        :type password: str or None
+
+        :return: return the :class:`Account` object or None if the account can not be used.
+        :type: :class:`Account` or None
+
+        >>> account = ocean.create_account('my_password')
+        """
+        account = None
+        squid_model = self.get_squid_model()
+        if squid_model:
+            local_address = squid_model.create_account(password)
+            if local_address:
+                account = Account(self, local_address, password)
+        else:
+            address = secrets.token_hex(20)
+            account = Account(self, address, password)
+
+        return account
 
     @property
     def accounts(self):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 import pytest
 import secrets
+import logging
 
 from tests.integration.libs.integration_test_config import integrationTestConfig
 
@@ -13,6 +14,7 @@ def ocean():
     result = Ocean(keeper_url=integrationTestConfig.keeper_url,
             contracts_path=integrationTestConfig.contracts_path,
             gas_limit=integrationTestConfig.gas_limit,
+            log_level=logging.WARNING
     )
     return result
 

--- a/tests/integration/core/test_accounts.py
+++ b/tests/integration/core/test_accounts.py
@@ -7,6 +7,7 @@
 import unittest
 import os
 import logging
+import secrets
 
 from starfish import Ocean
 from squid_py import Ocean as SquidOcean
@@ -52,3 +53,9 @@ def test_account_list():
     accounts = ocean.accounts
     assert len(accounts) > 1
     assert publisher_account.is_address_equal((list(accounts)[0]))
+
+def test_account_creation():
+    ocean = Ocean(CONFIG_PARAMS)
+    password = secrets.token_hex(120)
+    account = ocean.create_account(password)
+    assert(account)

--- a/tests/integration/core/test_accounts.py
+++ b/tests/integration/core/test_accounts.py
@@ -9,53 +9,45 @@ import os
 import logging
 import secrets
 
-from starfish import Ocean
+from starfish import Ocean, logger
 from squid_py import Ocean as SquidOcean
 from squid_py import Config as SquidConfig
 
-CONFIG_PARAMS = {'contracts_path': 'artifacts', 'keeper_url': 'http://localhost:8545' }
-PUBLISHER_ACCOUNT = { 'address': '0x00bd138abd70e2f00903268f3db08f2d25677c9e', 'password': 'node0'}
+def test_account_load(ocean, config):
+    # address only
+    account = ocean.get_account(config.publisher_account['address'])
+    assert(account)
+    assert(account.address == config.publisher_account['address'])
+    assert(account.password is None)
 
+    # address and password as a tuple
+    account = ocean.get_account(config.publisher_account)
+    assert(account)
+    assert(account.address == config.publisher_account['address'])
+    assert(account.password == config.publisher_account['password'])
 
-def test_account_load():
-    ocean = Ocean(CONFIG_PARAMS, log_level=logging.DEBUG)
-    account = ocean.get_account(PUBLISHER_ACCOUNT['address'])
-    assert account
-    assert account.address == PUBLISHER_ACCOUNT['address']
-    assert account.password is None
-
-    account = ocean.get_account(PUBLISHER_ACCOUNT)
-    assert account
-    assert account.address == PUBLISHER_ACCOUNT['address']
-    assert account.password == PUBLISHER_ACCOUNT['password']
-
-def test_account_get_squid_account():
-    ocean = Ocean(CONFIG_PARAMS)
-    account = ocean.get_account(PUBLISHER_ACCOUNT)
-    assert account
+def test_account_get_squid_account(ocean, config):
+    account = ocean.get_account(config.publisher_account)
+    assert(account)
     squid_account = account._squid_account
-    assert squid_account
-    assert account.is_valid
+    assert(squid_account)
+    assert(account.is_valid)
 
-
-def test_account_get_balance():
-    ocean = Ocean(CONFIG_PARAMS)
-    account = ocean.get_account(PUBLISHER_ACCOUNT)
-    assert account
-    assert account.unlock()
+def test_account_get_balance(ocean, config):
+    account = ocean.get_account(config.publisher_account)
+    assert(account)
+    assert(account.unlock())
     account.request_tokens(1)
-    assert account.ocean_balance
-    assert account.ether_balance
+    assert(account.ocean_balance)
+    assert(account.ether_balance)
 
-def test_account_list():
-    ocean = Ocean(CONFIG_PARAMS)
-    publisher_account = ocean.get_account(PUBLISHER_ACCOUNT)
+def test_account_list(ocean, config):
+    publisher_account = ocean.get_account(config.publisher_account)
     accounts = ocean.accounts
-    assert len(accounts) > 1
-    assert publisher_account.is_address_equal((list(accounts)[0]))
+    assert(len(accounts) > 1)
+    assert(publisher_account.is_address_equal((list(accounts)[0])))
 
-def test_account_creation():
-    ocean = Ocean(CONFIG_PARAMS)
+def test_account_creation(ocean):
     password = secrets.token_hex(120)
     account = ocean.create_account(password)
     assert(account)

--- a/tests/unit/libs/unit_test_account.py
+++ b/tests/unit/libs/unit_test_account.py
@@ -2,16 +2,19 @@ import secrets
 
 class UnitTestAccount():
 
-    def __init__(self):
+    def __init__(self, password = None):
         self.test_address = '0x' + secrets.token_hex(20)
-        self.test_password = secrets.token_hex(32)
+        if password:
+            self.test_password = password
+        else:
+            self.test_password = secrets.token_hex(32)
         self.test_ether = secrets.randbelow(10000000)
         self.test_tokens = secrets.randbelow(10000000)
 
     @property
     def as_tuple(self):
         return (self.test_address, self.test_password)
-        
+
     @property
     def as_dict(self):
         return {'address': self.test_address, 'password': self.test_password}

--- a/tests/unit/libs/unit_test_config.py
+++ b/tests/unit/libs/unit_test_config.py
@@ -14,5 +14,9 @@ class UnitTestConfig():
             account = UnitTestAccount()
             self.accounts[index] = account
 
+    def create_account(self, password):
+        account = UnitTestAccount(password)
+        self.accounts[len(self.accounts)] = account
+        return account.test_address
 
 unitTestConfig = UnitTestConfig()

--- a/tests/unit/mocks/mock_squid_model.py
+++ b/tests/unit/mocks/mock_squid_model.py
@@ -23,7 +23,8 @@ class MockSquidModel():
                 if address.lower() == test_account.test_address.lower():
                     account = Mock()
                     account.address = address
-                    account.password = password
+                    if password:
+                        account.password = password
                     return account
         return None
 
@@ -51,7 +52,11 @@ class MockSquidModel():
                 balance.ocn = test_account.test_tokens
                 return balance
         return 0
-        
+
+    def create_account(self, password = None):
+        address = unitTestConfig.create_account(password)
+        return self.get_account(address, password)
+
     def request_tokens(self, account, value):
         found_account = self.get_account(account.address)
         if found_account.address == account.address:

--- a/tests/unit/ocean/test_ocean.py
+++ b/tests/unit/ocean/test_ocean.py
@@ -34,7 +34,7 @@ def test_ocean_init_empty(config):
     assert(not ocean.search_operations('test search text') is None)
     accounts = ocean.accounts
     assert(len(accounts) == 0)
-    
+
     assert(ocean.keeper_url == None)
     assert(ocean.contracts_path == None)
     assert(ocean.gas_limit == 0)
@@ -63,6 +63,11 @@ def test_get_account(ocean, config):
     account = ocean.get_account(config.accounts[0].as_dict)
     assert(account)
 
+def test_create_account(ocean, config):
+    password = secrets.token_hex(32)
+    account = ocean.create_account(password)
+    assert(account)
+    
 def test_accounts(ocean, config):
     accounts = ocean.accounts
     assert(accounts)


### PR DESCRIPTION
Minor changes to bring the _memory_ based agent and _memory_ usage up to standard.

+ corrected the help files, to show the new memory and new agents
+ fixed the example files
+ added in a new `Ocean.create_account' method, to create a local account