### PR TITLE
add test of examples

### DIFF
--- a/tests/integration/examples/test_examples.py
+++ b/tests/integration/examples/test_examples.py
@@ -1,0 +1,20 @@
+""""
+
+Test examples
+
+"""
+
+def test_register_asset():
+    from examples.register_asset import main
+    main()
+
+
+def test_register_memory_asset():
+    from examples.register_memory_asset import main
+    main()
+
+
+def test_surfer_memory_asset():
+    from examples.surfer_memory_asset import main
+    # Todo: Surfer example is not working standalone
+    # main()


### PR DESCRIPTION
include the examples for testing into the integration tests.
This just makes sure the example runs with no errors.

Currently the `surfer_memory_asset' example is not working, will need to fix this for the next changes for Surfer API integration.