### PR TITLE
remove init network

### DIFF
--- a/starfish/agent/squid_agent.py
+++ b/starfish/agent/squid_agent.py
@@ -80,21 +80,6 @@ class SquidAgent(AgentBase):
         self._secret_store_url = kwargs.get('secret_store_url', 'http://localhost:12001')
         self._storage_path = kwargs.get('storage_path', 'squid_py.db')
 
-    def init_network(self, account):
-        """
-        For test networks, and networks that do not have ocean agreements installed, you need to call this
-        method to create a basic service level agreement template.
-
-        :param account: account object to use too create the SLA template.
-        :type account: :class:.Account object
-
-        :return: True if a new service level agreement template was created, else False.
-        :type: boolean
-
-        """
-        model = self.squid_model
-        return model.auto_create_service_agreement_template(account._squid_account)
-
     def register_asset(self, asset, account):
         """
 

--- a/starfish/models/squid_model.py
+++ b/starfish/models/squid_model.py
@@ -273,19 +273,6 @@ class SquidModel():
 
         return self._squid_ocean.agreements.is_access_granted(service_agreement_id, did, account_address)
 
-    def auto_create_service_agreement_template(self, account):
-        """
-
-        Called to auto create service level agremment template on test networks
-
-        Currently squid - will fail on simple tasks if there is no SLA templated defined on the block chain
-
-        :param account: Account to use to create the SLA template if it does not exist
-        """
-#        if not self.is_service_agreement_template_registered(ACCESS_SERVICE_TEMPLATE_ID):
-#            return self.register_service_agreement_template(ACCESS_SERVICE_TEMPLATE_ID, account)
-        return False
-
     def _as_config_dict(self, options=None):
         """
 

--- a/tests/integration/core/test_squid.py
+++ b/tests/integration/core/test_squid.py
@@ -44,10 +44,6 @@ def test_asset(ocean, metadata, config):
     publisher_account.unlock()
     publisher_account.request_tokens(20)
 
-    # check to see if the sla template has been registered, this is only run on
-    # new networks, especially during a travis test run..
-    agent.init_network(publisher_account)
-
     listing = _register_asset_for_sale(agent, metadata, publisher_account)
     assert listing
     assert publisher_account

--- a/tests/integration/invoke/test_brizo_invoke.py
+++ b/tests/integration/invoke/test_brizo_invoke.py
@@ -43,9 +43,6 @@ def test_invoke(ocean, metadata, config):
     publisher_account.unlock()
     publisher_account.request_tokens(20)
 
-    # check to see if the sla template has been registered, this is only run on
-    agent.init_network(publisher_account)
-
     listing = _register_asset_for_sale(agent, metadata, publisher_account)
     assert listing
     assert publisher_account

--- a/tests/integration/invoke/test_invoke_oa.py
+++ b/tests/integration/invoke/test_invoke_oa.py
@@ -52,10 +52,6 @@ def purchase_asset(ocean, metadata, config):
     publisher_account.unlock()
     publisher_account.request_tokens(20)
 
-    # check to see if the sla template has been registered, this is only run on
-    # new networks, especially during a travis test run..
-    agent.init_network(publisher_account)
-
     listing = _register_asset_for_sale(agent, metadata, publisher_account)
     assert listing
     assert publisher_account


### PR DESCRIPTION
The old squid-py we had to add in the SLA templates into a new network before the SLA templates can be used. 
This has now been fixed in the current squid-py, all of the SLA templates are auto added by squid-py.
