### PR TITLE
Feature/surfer intregration wip 3

### DIFF
--- a/examples/register_asset.py
+++ b/examples/register_asset.py
@@ -78,7 +78,7 @@ def main():
     listing = agent.register_asset(asset, account)
 
     # Print out the listing did and listing data.
-    print('the listing', listing.did, listing.data)
+    print('the listing', listing.listing_id, listing.data)
 
 if __name__ == '__main__':
     main()

--- a/examples/register_memory_asset.py
+++ b/examples/register_memory_asset.py
@@ -16,10 +16,10 @@ def main():
 
     # create a new test account to register
     register_account = ocean.create_account('any old password')
-    
+
     # print the new account
     print('my new register account', register_account)
-    
+
     # Now create a memory asset
     asset = MemoryAsset(data='Some test data that I want to save for this asset')
 
@@ -33,7 +33,7 @@ def main():
     listing = agent.register_asset(asset, register_account)
 
     # Print out the listing did and listing data.
-    print('memory listing', listing.did, listing.data)
+    print('memory listing', listing.listing_id, listing.data)
 
 
 if __name__ == '__main__':

--- a/starfish/agent/agent_base.py
+++ b/starfish/agent/agent_base.py
@@ -64,15 +64,15 @@ class AgentBase(ABC):
         pass
 
     @abstractmethod
-    def get_listing(self, did):
+    def get_listing(self, listing_id):
         """
 
-        Return an listing on the listing's DID.
+        Return an listing from the given listing_id.
 
-        :param str did: DID of the listing.
+        :param str listing_id: Id of the listing.
 
-        :return: a registered asset given a DID of the asset
-        :type: :class:`.SquidAsset` class
+        :return: a registered listing given a Id of the listing
+        :type: :class:`.Listing` class
 
         """
         pass

--- a/starfish/agent/invoke_agent.py
+++ b/starfish/agent/invoke_agent.py
@@ -34,14 +34,17 @@ class InvokeAgent:
     def get_operation(self,did):
         return Operation(self,did)
 
-    def get_listing(self, did):
+    def get_listing(self, listing_id):
         """
 
-        Return an listing on the listing's DID-will be supported in future.
+        Return an listing from the given listing_id.
+
+        :param str listing_id: Id of the listing.
+
+        :return: a registered listing given a Id of the listing
+        :type: :class:`.Listing` class
 
         """
-        pass
-
 
     def purchase(self, listing, account):
         """

--- a/starfish/agent/squid_agent.py
+++ b/starfish/agent/squid_agent.py
@@ -151,27 +151,24 @@ class SquidAgent(AgentBase):
 
         return model.validate_metadata(asset.metadata)
 
-    def get_listing(self, did):
+    def get_listing(self, listing_id):
         """
+        Return an listing from the given listing_id.
 
-        Return an listing on the listing's DID.
+        :param str listing_id: Id of the listing.
 
-        :param str did: DID of the listing.
-
-        :return: a registered asset given a DID of the asset
-        :type: :class:`.SquidAsset` class
+        :return: a registered listing given a Id of the listing
+        :type: :class:`.Listing` class
 
         """
         listing = None
-        if SquidAgent.is_did_valid(did):
-            model = self.squid_model
-            ddo = model.read_asset(did)
+        model = self.squid_model
 
-            if ddo:
-                asset = SquidAsset(ddo.metadata, ddo.did)
-                listing = Listing(self, ddo.did, asset, ddo)
-        else:
-            raise ValueError(f'Invalid did "{did}" for an asset')
+        ddo = model.read_asset(listing_id)
+
+        if ddo:
+            asset = SquidAsset(ddo.metadata, ddo.did)
+            listing = Listing(self, listing_id, asset, ddo)
 
         return listing
 

--- a/starfish/agent/surfer_agent.py
+++ b/starfish/agent/surfer_agent.py
@@ -157,36 +157,40 @@ class SurferAgent(AgentBase):
         return model.upload_asset_data(remove_0x_prefix(asset.asset_id), asset.data)
 
 
-    def get_listing(self, did):
+    def get_listing(self, listing_id):
         """
-        this method is deprecated, as register_asset returns a listing.
-        Return an listing on the listing's DID.
+        Return an listing on the listings id.
 
-        :param str did: DID of the listing, this includes the did of the Surfer Agent Server.
+        :param str listing_id: Id of the listing.
 
-        :return: a registered asset given a DID of the asset
+        :return: a listing object
         :type: :class:`.Asset` class
 
         """
+        model = self._get_surferModel()
         listing = None
-        if SurferAgent.is_did_valid(did):
-
-            data = did_parse(did)
-
-            asset_id = data['path']
-            agent_did = 'did:op:' + data['id']
-            model = self._get_surferModel(agent_did)
-            endpoint = model.get_endpoint('metadata')
-            result_data = model.read_metadata(asset_id, endpoint)
-
-            if result_data:
-                metadata = json.loads(result_data['metadata_text'])
+        data = model.get_listing(listing_id)
+        if data:
+            asset_id = data['assetid']
+            read_metadata = model.read_metadata(asset_id)
+            if read_metadata:
+                metadata = json.loads(read_metadata['metadata_text'])
+                did = f'{self._did}/{asset_id}'
                 asset = MemoryAsset(metadata, did)
-                listing = Listing(self, did, asset, self._ddo)
-        else:
-            raise ValueError(f'Invalid did "{did}" for an asset')
-
+                listing = Listing(self, did, asset, data, data['id'])
         return listing
+
+    def update_listing(self, listing):
+        """
+
+        Update the listing to the agent server.
+
+        :param listing: Listing object to update
+        :type listing: :class:`.Listing` class
+
+        """
+        model = self._get_surferModel()
+        return model.update_listing(listing.listing_id, listing.data)
 
     def search_listings(self, text, sort=None, offset=100, page=0):
         """

--- a/starfish/agent/surfer_agent.py
+++ b/starfish/agent/surfer_agent.py
@@ -177,7 +177,7 @@ class SurferAgent(AgentBase):
             agent_did = 'did:op:' + data['id']
             model = self._get_surferModel(agent_did)
             endpoint = model.get_endpoint('metadata')
-            result_data = model.read_asset(asset_id, endpoint)
+            result_data = model.read_metadata(asset_id, endpoint)
 
             if result_data:
                 metadata = json.loads(result_data['metadata_text'])

--- a/starfish/agent/surfer_agent.py
+++ b/starfish/agent/surfer_agent.py
@@ -212,6 +212,7 @@ class SurferAgent(AgentBase):
             my_result = agent.search_registered_assets('weather', None, 100, 3)
 
         """
+        # TODO: implement search listing in surfer
         pass
 
     def purchase_asset(self, listing, account):

--- a/starfish/agent/surfer_agent.py
+++ b/starfish/agent/surfer_agent.py
@@ -133,7 +133,7 @@ class SurferAgent(AgentBase):
             did = f'{self._did}/{asset_id}'
             asset.set_did(did)
             data = model.create_listing(asset_id)
-            listing = Listing(self, did, asset, data, data['id'])
+            listing = Listing(self, data['id'], asset, data)
         return listing
 
     def validate_asset(self, asset):
@@ -177,7 +177,7 @@ class SurferAgent(AgentBase):
                 metadata = json.loads(read_metadata['metadata_text'])
                 did = f'{self._did}/{asset_id}'
                 asset = MemoryAsset(metadata, did)
-                listing = Listing(self, did, asset, data, data['id'])
+                listing = Listing(self, data['id'], asset, data)
         return listing
 
     def update_listing(self, listing):

--- a/starfish/listing/listing.py
+++ b/starfish/listing/listing.py
@@ -38,6 +38,34 @@ class Listing(ListingBase):
 
         return self._agent.purchase_asset(self, account)
 
+    def set_published(self, value):
+        """
+
+        Set the published value
+
+        :params boolean value: Published value True or False
+
+        """
+        if self._data and isinstance(self._data, dict) and 'status' in self._data:
+            if value:
+                self._data['status'] = 'published'
+            else:
+                self._data['status'] = 'unpublished'
+
+    @property
+    def is_published(self):
+        """
+
+        Return a True if this listing is published
+
+        :return: True of False if this listing is published
+        :type: boolean
+
+        """
+        if self._data and isinstance(self._data, dict) and 'status' in self._data:
+            return self._data['status'] == 'published'
+        return False
+
     def __str__(self):
         s = 'Listing: agent=' + self._agent.__class__.__name__ + ', '
         s += 'did=' + self._did + ', '

--- a/starfish/listing/listing.py
+++ b/starfish/listing/listing.py
@@ -68,8 +68,7 @@ class Listing(ListingBase):
 
     def __str__(self):
         s = 'Listing: agent=' + self._agent.__class__.__name__ + ', '
-        s += 'did=' + self._did + ', '
-        s += 'asset=' + self._asset.__class__.__name__ + ', '
         s += 'listing_id=' + self._listing_id + ', '
+        s += 'asset=' + self._asset.__class__.__name__ + ', '
         s += 'data=' + str(self._data)
         return s

--- a/starfish/listing/listing_base.py
+++ b/starfish/listing/listing_base.py
@@ -11,19 +11,18 @@ class ListingBase(ABC):
 
         :param agent: agent object that created the listing.
         :type agent: :class:`.Agent` object to assign to this Listing
-        :param str did: did of the listing, this can be the did of the underling asset.
+        :param str listing_id: id of the listing.
         :param asset: the core asset for this listing
         :type asset: :class:`.Asset` object
         :param data: data of the listing
         :type data: dict
     """
-    def __init__(self, agent, did, asset, data, listing_id=None):
+    def __init__(self, agent, listing_id, asset, data):
         """init the the Listing Object Base with the agent instance"""
         self._agent = agent
-        self._did = did
+        self._listing_id=listing_id
         self._asset = asset
         self._data = data
-        self._listing_id=listing_id
         super().__init__()
 
     @abstractmethod
@@ -50,14 +49,6 @@ class ListingBase(ABC):
         :type: :class:`.SquidAgent`
         """
         return self._agent
-
-    @property
-    def did(self):
-        """
-        :return: did of the listing
-        :type: string
-        """
-        return self._did
 
     @property
     def data(self):
@@ -95,4 +86,4 @@ class ListingBase(ABC):
         :return: True if this listing is empty else False.
         :type: boolean
         """
-        return self._did is None or self._did is None or self._asset is None
+        return self._listing_id is None or self._asset is None

--- a/starfish/models/surfer_model.py
+++ b/starfish/models/surfer_model.py
@@ -69,20 +69,19 @@ class SurferModel():
         :type: dict
         """
         result = None
-        metadata_text = json.dumps(metadata)
         endpoint = self.get_endpoint('metadata')
-        saved_asset_id = self.save_metadata(metadata_text, endpoint)
+        saved_asset_id = self.save_metadata(metadata, endpoint)
         result = {
                 'asset_id': saved_asset_id,
-                'metadata_text': metadata_text,
+                'metadata': metadata,
             }
         return result
 
-    def save_metadata(self, metadata_text, endpoint):
+    def save_metadata(self, metadata, endpoint):
         """save metadata to the agent server, using the asset_id and metadata"""
         url = endpoint
         logger.debug(f'metadata save url {url}')
-        response = SurferModel._http_client.post(url, json=metadata_text, headers=self._headers)
+        response = SurferModel._http_client.post(url, json=metadata, headers=self._headers)
         if response and response.status_code == requests.codes.ok:
 
             json = response.json()
@@ -125,7 +124,7 @@ class SurferModel():
             raise ValueError(msg)
         return None
 
-    def read_asset(self, asset_id, endpoint):
+    def read_metadata(self, asset_id, endpoint):
         """read the metadata from a service agent using the asset_id"""
 
         result = None
@@ -140,7 +139,7 @@ class SurferModel():
                 }
                 # convert to str if bytes
                 if isinstance(result['metadata_text'], bytes):
-                    result['metadat_text'] = response.content.encode('utf-8')
+                    result['metadata_text'] = response.content.decode('utf-8')
             else:
                 logger.warning(f'metadata asset read {asset_id} response returned {response}')
         return result

--- a/tests/integration/core/test_memory.py
+++ b/tests/integration/core/test_memory.py
@@ -39,11 +39,11 @@ def test_asset(ocean, metadata, config):
     assert listing
     assert publisher_account
 
-    listing_did = listing.asset.did
+    listing_id = listing.listing_id
     # start to test getting the asset from storage
-    listing = agent.get_listing(listing_did)
+    listing = agent.get_listing(listing_id)
     assert listing
-    assert listing.asset.did == listing_did
+    assert listing.listing_id == listing_id
 
 
     purchase_account = ocean.get_account(config.purchaser_account)

--- a/tests/integration/test_use_cases/test_01_connect_to_ocean.py
+++ b/tests/integration/test_use_cases/test_01_connect_to_ocean.py
@@ -1,7 +1,11 @@
 """
 
 
-test_01_connect_to_ocean
+    test_01_connect_to_ocean
+
+
+    As a developer working with Ocean,
+    I need a way to connect to the Ocean Network
 
 """
 
@@ -24,9 +28,9 @@ def test_01_connect_to_surfer(ocean, config):
     assert(did)
     ddo = {
         'name': 'Test ddo',
-        'value': secrets.token_hex(64) 
+        'value': secrets.token_hex(64)
     }
-    
+
     ocean.register_did(did, json.dumps(ddo), publisher_account)
     resolve_ddo = ocean.resolve_did(did)
     assert(resolve_ddo)

--- a/tests/integration/test_use_cases/test_02_asset_identity.py
+++ b/tests/integration/test_use_cases/test_02_asset_identity.py
@@ -1,6 +1,10 @@
 """
     test_02_asset_identity
 
+
+    As a developer working with Ocean,
+    I need a stable identifier (Asset ID) for an arbitrary asset in the Ocean ecosystem
+
 """
 
 import secrets

--- a/tests/integration/test_use_cases/test_03_agent_identity.py
+++ b/tests/integration/test_use_cases/test_03_agent_identity.py
@@ -1,6 +1,11 @@
 """
     test_03_agent_identity
 
+
+    As a developer working with Ocean,
+    I need a stable identifier (Agent ID) for an arbitrary Agent in the Ocean ecosystem
+    This test class with validate the DID and DDO format and and their data
+
 """
 
 import secrets

--- a/tests/integration/test_use_cases/test_04_agent_registration.py
+++ b/tests/integration/test_use_cases/test_04_agent_registration.py
@@ -1,6 +1,10 @@
 """
     test_04_agent_registration
 
+
+    As a developer building or managing an Ocean Agent,
+    I need to be able to register my Agent on the network and obtain an Agent ID
+
 """
 
 from starfish.agent import SurferAgent

--- a/tests/integration/test_use_cases/test_05_agent_endpoint_update.py
+++ b/tests/integration/test_use_cases/test_05_agent_endpoint_update.py
@@ -1,6 +1,10 @@
 """
     test_05_agent_endpoint_update
 
+
+    As a developer managing a Ocean Agent,
+    I need to be able to update service endpoints for my Agent
+ 
 """
 
 import re

--- a/tests/integration/test_use_cases/test_06_agent_endpoint_query.py
+++ b/tests/integration/test_use_cases/test_06_agent_endpoint_query.py
@@ -1,0 +1,30 @@
+"""
+    test_06_agent_endpoint_query
+
+
+    As a developer working with Ocean,
+    I need to obtain service endpoints for an arbitrary Agent in the Ocean ecosystem
+
+"""
+
+import re
+
+from starfish.agent import SurferAgent
+from starfish.ddo.starfish_ddo import StarfishDDO
+
+
+
+def test_05_agent_endpoint_query(ocean, surfer_agent):
+
+    endpoint = surfer_agent.get_endpoint('metadata')
+    assert(re.search('/meta/data', endpoint))
+    endpoint = surfer_agent.get_endpoint('storage')
+    assert(re.search('/assets', endpoint))
+    endpoint = surfer_agent.get_endpoint('invoke')
+    assert(re.search('/data$', endpoint))
+    endpoint = surfer_agent.get_endpoint('market')
+    assert(re.search('/market$', endpoint))
+    endpoint = surfer_agent.get_endpoint('trust')
+    assert(re.search('/trust$', endpoint))
+    endpoint = surfer_agent.get_endpoint('auth')
+    assert(re.search('/auth$', endpoint))

--- a/tests/integration/test_use_cases/test_07_metadata_access.py
+++ b/tests/integration/test_use_cases/test_07_metadata_access.py
@@ -20,8 +20,7 @@ def test_07_metadata_access(ocean, surfer_agent, metadata):
     asset = MemoryAsset(metadata=metadata, data=test_data)
     listing = surfer_agent.register_asset(asset)
     assert(not listing is None)
-    did = listing.did
-    assert(did)
+    assert(listing.listing_id)
     store_listing = surfer_agent.get_listing(listing.listing_id)
     assert(store_listing)
     assert(store_listing.asset.asset_id)

--- a/tests/integration/test_use_cases/test_07_metadata_access.py
+++ b/tests/integration/test_use_cases/test_07_metadata_access.py
@@ -22,7 +22,7 @@ def test_07_metadata_access(ocean, surfer_agent, metadata):
     assert(not listing is None)
     did = listing.did
     assert(did)
-    store_listing = surfer_agent.get_listing(did)
+    store_listing = surfer_agent.get_listing(listing.listing_id)
     assert(store_listing)
     assert(store_listing.asset.asset_id)
     assert(store_listing.asset.metadata)

--- a/tests/integration/test_use_cases/test_07_metadata_access.py
+++ b/tests/integration/test_use_cases/test_07_metadata_access.py
@@ -1,0 +1,29 @@
+"""
+    test_07_metadata_access
+
+    As a developer working with Ocean,
+    I need a way to request metadata for an arbitrary asset
+
+"""
+
+import secrets
+import json
+
+from starfish.asset import MemoryAsset
+from starfish.agent import SurferAgent
+from starfish.ddo.starfish_ddo import StarfishDDO
+
+
+
+def test_07_metadata_access(ocean, surfer_agent, metadata):
+    test_data = secrets.token_hex(1024)
+    asset = MemoryAsset(metadata=metadata, data=test_data)
+    listing = surfer_agent.register_asset(asset)
+    assert(not listing is None)
+    did = listing.did
+    assert(did)
+    store_listing = surfer_agent.get_listing(did)
+    assert(store_listing)
+    assert(store_listing.asset.asset_id)
+    assert(store_listing.asset.metadata)
+    assert(store_listing.asset.metadata == listing.asset.metadata)

--- a/tests/integration/test_use_cases/test_08_asset_registration.py
+++ b/tests/integration/test_use_cases/test_08_asset_registration.py
@@ -1,0 +1,30 @@
+"""
+    test_08_asset_registration
+
+    As a developer working with Ocean,
+    I need a way to register a new asset with Ocean
+
+"""
+
+import secrets
+import json
+
+from starfish.asset import MemoryAsset
+from starfish.agent import SurferAgent
+from starfish.ddo.starfish_ddo import StarfishDDO
+
+
+
+def test_08_asset_registration(surfer_agent, metadata):
+    test_data = secrets.token_hex(1024)
+    asset1 = MemoryAsset(metadata=metadata, data=test_data)
+    listing1 = surfer_agent.register_asset(asset1)
+    assert(listing1)
+    assert(listing1.asset)
+
+    asset2 = MemoryAsset(metadata=metadata, data=test_data)
+    listing2 = surfer_agent.register_asset(asset2)
+    assert(listing2)
+    assert(listing2.asset)
+
+    assert(listing1.asset.asset_id == listing2.asset.asset_id)

--- a/tests/integration/test_use_cases/test_09_construct_service_agreement.py
+++ b/tests/integration/test_use_cases/test_09_construct_service_agreement.py
@@ -1,0 +1,13 @@
+"""
+    test_09_construct_service_agreement
+
+    As a developer working with Ocean,
+    I need a way to create a valid service agreement that I can offer to others for puchase
+
+"""
+
+
+
+
+def test_09_construct_service_agreement():
+    pass

--- a/tests/integration/test_use_cases/test_10_asset_upload.py
+++ b/tests/integration/test_use_cases/test_10_asset_upload.py
@@ -1,8 +1,8 @@
 """
     test_10_asset_upload
 
-    As a developer working with Ocean,
-    I need a way to create a valid service agreement that I can offer to others for puchase
+    As a developer working with an Ocean marketplace,
+    I need a way to upload my asset with a service agreement
 
 """
 

--- a/tests/integration/test_use_cases/test_10_asset_upload.py
+++ b/tests/integration/test_use_cases/test_10_asset_upload.py
@@ -1,0 +1,21 @@
+"""
+    test_10_asset_upload
+
+    As a developer working with Ocean,
+    I need a way to create a valid service agreement that I can offer to others for puchase
+
+"""
+
+import secrets
+
+from starfish.asset import MemoryAsset
+
+
+def test_10_asset_upload(surfer_agent, metadata):
+    test_data = secrets.token_hex(1024)
+    asset = MemoryAsset(metadata=metadata, data=test_data)
+    listing = surfer_agent.register_asset(asset)
+    assert(listing)
+    assert(listing.asset)
+
+    assert(surfer_agent.upload_asset(listing.asset))

--- a/tests/integration/test_use_cases/test_12_listing_publish.py
+++ b/tests/integration/test_use_cases/test_12_listing_publish.py
@@ -11,13 +11,12 @@ import secrets
 from starfish.asset import MemoryAsset
 
 
-def test_10_asset_upload(surfer_agent, metadata):
+def test_12_listing_publish(surfer_agent, metadata):
     test_data = secrets.token_hex(1024)
     asset = MemoryAsset(metadata=metadata, data=test_data)
     listing = surfer_agent.register_asset(asset)
     assert(listing)
     assert(listing.asset)
-    print(listing.listing_id, listing.asset.asset_id)
 
     assert(not listing.is_published)
 

--- a/tests/integration/test_use_cases/test_12_listing_publish.py
+++ b/tests/integration/test_use_cases/test_12_listing_publish.py
@@ -1,0 +1,31 @@
+"""
+    test_12_listing_publish
+
+    As a developer working with an Ocean marketplace,
+    I need a way to unpublish my asset (i.e. remove relevant listings) from a marketplace
+
+"""
+
+import secrets
+
+from starfish.asset import MemoryAsset
+
+
+def test_10_asset_upload(surfer_agent, metadata):
+    test_data = secrets.token_hex(1024)
+    asset = MemoryAsset(metadata=metadata, data=test_data)
+    listing = surfer_agent.register_asset(asset)
+    assert(listing)
+    assert(listing.asset)
+    print(listing.listing_id, listing.asset.asset_id)
+
+    assert(not listing.is_published)
+
+    listing.set_published(True)
+    assert(listing.is_published)
+
+    assert(surfer_agent.update_listing(listing))
+
+    read_listing = surfer_agent.get_listing(listing.listing_id)
+    assert(read_listing)
+    assert(read_listing.is_published)

--- a/tests/integration/test_use_cases/test_13_asset_listing_search.py
+++ b/tests/integration/test_use_cases/test_13_asset_listing_search.py
@@ -1,0 +1,19 @@
+"""
+    test_13_asset_listing_search
+
+    As a developer building client code to interact with an Ocean marketplace,
+    I need a way to search available asset listings
+
+"""
+
+import secrets
+
+from starfish.asset import MemoryAsset
+
+
+def test_13_asset_listing_search(surfer_agent, metadata):
+    test_data = secrets.token_hex(1024)
+    asset = MemoryAsset(metadata=metadata, data=test_data)
+    listing = surfer_agent.register_asset(asset)
+    assert(listing)
+    assert(listing.asset)

--- a/tests/unit/agent/test_memory_agent.py
+++ b/tests/unit/agent/test_memory_agent.py
@@ -20,36 +20,36 @@ def _register_asset(ocean, metadata, config):
     assert(asset)
     listing = agent.register_asset(asset, account)
     return (listing, agent, asset)
-    
+
 def _purchase_asset(ocean, metadata, config):
     listing, agent, asset = _register_asset(ocean, metadata, config)
     account = ocean.get_account(config.accounts[1].as_dict)
     purchase = agent.purchase_asset(listing, account)
     return purchase, listing, agent, asset, account
-    
+
 def test_init(ocean):
     agent = MemoryAgent(ocean)
     assert(agent)
-    
+
 def test_register_asset(ocean, metadata, config):
     listing, agent, asset = _register_asset(ocean, metadata, config)
     assert(listing)
-    assert(listing.did)
+    assert(listing.listing_id)
 
 def test_get_listing(ocean, metadata, config):
     listing, agent, asset = _register_asset(ocean, metadata, config)
-    found_listing = agent.get_listing(listing.did)
+    found_listing = agent.get_listing(listing.listing_id)
     assert(found_listing)
-    assert(found_listing.did == listing.did)
+    assert(found_listing.listing_id == listing.listing_id)
 
 def test_search_listings(ocean, metadata, config):
     listing, agent, asset = _register_asset(ocean, metadata, config)
-    listing_dids = agent.search_listings(metadata['base']['author'])
-    assert(listing_dids)
-    assert(len(listing_dids) > 0)
+    listing_ids = agent.search_listings(metadata['base']['author'])
+    assert(listing_ids)
+    assert(len(listing_ids) > 0)
     is_found = False
-    for did in listing_dids:
-        if did == listing.did:
+    for listing_id in listing_ids:
+        if listing_id == listing.listing_id:
             is_found = True
             break
     assert(is_found)
@@ -59,8 +59,8 @@ def test_purchase_asset(ocean, metadata, config):
     account = ocean.get_account(config.accounts[1].as_dict)
     purchase = agent.purchase_asset(listing, account)
     assert(purchase)
-    
-    
+
+
 def test_is_access_granted_for_asset(ocean, metadata, config):
     purchase, listing, agent, asset, account = _purchase_asset(ocean, metadata, config)
     assert(agent.is_access_granted_for_asset(asset, purchase.purchase_id, account))

--- a/tests/unit/agent/test_squid_agent.py
+++ b/tests/unit/agent/test_squid_agent.py
@@ -61,7 +61,7 @@ def test_init(ocean):
 def test_register_asset(ocean, metadata, config):
     listing, agent, asset = _register_asset(ocean, metadata, config)
     assert(listing)
-    assert(listing.did)
+    assert(listing.listing_id)
 
 def test_validate_asset(ocean, metadata):
     agent = SquidAgent(ocean, TEST_INIT_PARMS)
@@ -71,18 +71,18 @@ def test_validate_asset(ocean, metadata):
 
 def test_get_listing(ocean, metadata, config):
     listing, agent, asset = _register_asset(ocean, metadata, config)
-    found_listing = agent.get_listing(listing.did)
+    found_listing = agent.get_listing(listing.listing_id)
     assert(found_listing)
-    assert(found_listing.did == listing.did)
+    assert(found_listing.listing_id == listing.listing_id)
 
 def test_search_listings(ocean, metadata, config):
     listing, agent, asset = _register_asset(ocean, metadata, config)
-    listing_dids = agent.search_listings(metadata['base']['author'])
-    assert(listing_dids)
-    assert(len(listing_dids) > 0)
+    listing_ids = agent.search_listings(metadata['base']['author'])
+    assert(listing_ids)
+    assert(len(listing_ids) > 0)
     is_found = False
-    for did in listing_dids:
-        if did == listing.did:
+    for listing_id in listing_ids:
+        if listing_id == listing.listing_id:
             is_found = True
             break
     assert(is_found)


### PR DESCRIPTION
+ added tests for metadata saving and reading from Surfer
+ asset registration tests
+ add a service agreement test case ( empty)
+ asset upload test
+ update listing is_published
+ start on search listing.

For search listing Surfer only returns the complete list of listing elements, their is no text search as in Squid. So we will need to work out a possible solution for search listing in Surfer

Changed the listing class, so that it works for Squid and Surfer. In Squid listing_id is the asset_id, while Surfer has it's own listing_id.