### PR TITLE
Bump version: 0.2.2 → 0.3.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.2
+current_version = 0.3.0
 commit = True
 tag = True
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,7 @@ copyright = 'starfish-py contributors'
 author = 'starfish-py contributors'
 
 # The full version, including alpha/beta/rc tags
-release = '0.2.2'
+release = '0.3.0'
 # The short X.Y version
 release_parts = release.split('.')  # a list
 version = release_parts[0] + '.' + release_parts[1] + '.' + release_parts[2]

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/DEX-Company/starfish-py',
-    version='0.2.2',
+    version='0.3.0',
     zip_safe=False,
 )

--- a/starfish/__init__.py
+++ b/starfish/__init__.py
@@ -9,7 +9,7 @@
 """
 
 __author__ = """DEX.sg"""
-__version__ = '0.2.2'
+__version__ = '0.3.0'
 
 import logging
 


### PR DESCRIPTION
Version 0.3.0

squid-py: v0.6.5
barge: dex-2019-05-24