### PR TITLE
Version/v0 4 9

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.8
+current_version = 0.4.9
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Change Log
 
+### Release v0.4.9
+
+*  Allow the watch event list to check for valid consumer address before starting agreement ( simple white listing on asset purchase).
+*  Changed accounts to only support 'hosted' accounts for squid, but allow for local and host account setup.
+
 ### Release v0.4.8
 
 *  Remove SquidAsset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,42 +2,42 @@
 
 ### Release v0.4.9
 
-*  Allow the watch event list to check for valid consumer address before starting agreement ( simple white listing on asset purchase).
-*  Changed accounts to only support 'hosted' accounts for squid, but allow for local and host account setup.
+*   Allow the watch event list to check for valid consumer address before starting agreement ( simple white listing on asset purchase).
+*   Changed accounts to only support 'hosted' accounts for squid, but allow for local and host account setup.
 
 ### Release v0.4.8
 
-*  Remove SquidAsset
-*  Listing Data Price to use ocean tokens
-*  Squid assets to only read the 'file' part of metadata
-*  Squid agent to only return AssetBundle for the asset part of a listing
+*   Remove SquidAsset
+*   Listing Data Price to use ocean tokens
+*   Squid assets to only read the 'file' part of metadata
+*   Squid agent to only return AssetBundle for the asset part of a listing
 
 ### Release v0.4.7
 
-*  Supports: dex-2019-08-08
-*  Supports: squid-py 0.6.15
-*  New squid-agent method watch_provider_events
+*   Supports: dex-2019-08-08
+*   Supports: squid-py 0.6.15
+*   New squid-agent method watch_provider_events
 
- ### Release v0.4.6
-*  Fixed logging, so that only in test we setup the log level
-*  Add a test to see if we have already purchased an asset in squid
-*  Add MemoryAsset.save method
+### Release v0.4.6
+*   Fixed logging, so that only in test we setup the log level
+*   Add a test to see if we have already purchased an asset in squid
+*   Add MemoryAsset.save method
 
 ### Release v0.4.2
 
-*  Include DDO as a module in package.
+*   Include DDO as a module in package.
 
 ### Release v0.4.1
 
-*  Improved asset classes
-*  PD Test cases for file sharing
+*   Improved asset classes
+*   PD Test cases for file sharing
 
 ### Release v0.4.0
 
-*  Supports: squid-py: v0.6.11
-*  Supports: barge: dex-2019-06-17
+*   Supports: squid-py: v0.6.11
+*   Supports: barge: dex-2019-06-17
 
 ### Release v0.3.0
 
-*  Supports: squid-py: v0.6.5
-*  Supports: barge: dex-2019-05-24
+*   Supports: squid-py: v0.6.5
+*   Supports: barge: dex-2019-05-24

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,7 @@ copyright = 'starfish-py contributors'
 author = 'starfish-py contributors'
 
 # The full version, including alpha/beta/rc tags
-release = '0.4.8'
+release = '0.4.9'
 # The short X.Y version
 release_parts = release.split('.')  # a list
 version = release_parts[0] + '.' + release_parts[1] + '.' + release_parts[2]

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/DEX-Company/starfish-py',
-    version='0.4.8',
+    version='0.4.9',
     zip_safe=False,
 )

--- a/starfish/__init__.py
+++ b/starfish/__init__.py
@@ -9,7 +9,7 @@
 """
 
 __author__ = """DEX.sg"""
-__version__ = '0.4.8'
+__version__ = '0.4.9'
 
 import logging
 


### PR DESCRIPTION
### Release v0.4.9

*  Allow the watch event list to check for valid consumer address before starting agreement ( simple white listing on asset purchase).
*  Changed accounts to only support 'hosted' accounts for squid, but allow for local and host account setup.