### PR TITLE
Bump version: 0.4.11 → 0.5.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.11
+current_version = 0.5.0
 commit = True
 tag = True
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,7 @@ copyright = 'starfish-py contributors'
 author = 'starfish-py contributors'
 
 # The full version, including alpha/beta/rc tags
-release = '0.4.11'
+release = '0.5.0'
 # The short X.Y version
 release_parts = release.split('.')  # a list
 version = release_parts[0] + '.' + release_parts[1] + '.' + release_parts[2]

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/DEX-Company/starfish-py',
-    version='0.4.11',
+    version='0.5.0',
     zip_safe=False,
 )

--- a/starfish/__init__.py
+++ b/starfish/__init__.py
@@ -9,7 +9,7 @@
 """
 
 __author__ = """DEX.sg"""
-__version__ = '0.4.11'
+__version__ = '0.5.0'
 
 import logging
 


### PR DESCRIPTION
## Change Log

*   Upgrade to dex-2019-08-09
*   Removed FileAsset, MemoryAsset, RemoteAsset. Replaced with DataAsset
*   Cleanup documentation
*   Renamed Squid/Surfer Models to Squid/Surfer Agent Adapters
